### PR TITLE
feat: auto-bound methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,25 @@ Simple template helper to inject services into templates.
 
 ## Installation
 
-```
+```sh
 ember install ember-service-helper
 ```
 
 ## Usage
 
-Example using [`ember-responsive`](https://github.com/freshbooks/ember-responsive).
+There are two ways to invoke the `{{service}}` helper.
+
+- **`{{service serviceName}}`** — Returns the service itself.<br>
+  Like calling ```owner.lookup(`service:${serviceName}`)```
+- **`{{service serviceName methodName}}`** — Returns the method, bound to the instance.
+
+### Properties
+
+#### Getting Properties
+
+Example using the built-in `{{get}}` helper and
+[`ember-responsive`](https://github.com/freshbooks/ember-responsive). Note that
+`{{get}}` returns a bound reference.
 
 ```hbs
 {{#if (get (service "breakpoints") "isDesktop")}}
@@ -26,6 +38,43 @@ Example using [`ember-responsive`](https://github.com/freshbooks/ember-responsiv
 {{else}}
   Mobile breakpoint
 {{/if}}
+```
+
+#### Setting Properties
+
+Example using [`ember-set-helper`](https://github.com/pzuraq/ember-set-helper).
+
+```hbs
+<ColorPicker @update={{set (service "preferences") "favoriteColor"}}>
+```
+
+### Methods
+
+Example using the
+[`{{pick}}` helper from `ember-composable-helpers`](https://github.com/DockYard/ember-composable-helpers#pick)
+to get the `event.target.checked` property.
+
+```hbs
+<label>
+  Enable dark mode
+  <input
+    type="checkbox"
+    checked={{get (service "theme") "isDark"}}
+    {{on "input" (pick "target.checked" (service "theme" "toggleDarkMode"))}}
+  >
+</label>
+```
+
+```ts
+export default class ThemeService extends Service {
+  @tracked isDark = false;
+
+  toggleDarkMode(newValue = !this.isDark) {
+    // Even though this method isn't using `@action`, the `{{service}}` helper
+    // binds it to the service instance.
+    this.isDark = newValue;
+  }
+}
 ```
 
 ## Related

--- a/addon/helpers/service.js
+++ b/addon/helpers/service.js
@@ -3,10 +3,22 @@ import Helper from '@ember/component/helper';
 import { assert } from '@ember/debug';
 
 export default class ServiceHelper extends Helper {
-  compute([serviceName]) {
+  compute([serviceName, methodName]) {
     const service = getOwner(this).lookup(`service:${serviceName}`);
     assert(`The service '${serviceName}' does not exist`, service);
 
-    return service;
+    if (!methodName) return service;
+    assert(
+      `If specified, the second parameter must be the name of a method. Received: '${methodName}'`,
+      typeof methodName === 'string' || typeof methodName === 'symbol',
+    );
+
+    const method = service[methodName];
+    assert(
+      `'${methodName}' is not a method on '${serviceName}'.`,
+      typeof method === 'function',
+    );
+
+    return method.bind(service);
   }
 }

--- a/tests/integration/helpers/service-test.js
+++ b/tests/integration/helpers/service-test.js
@@ -1,4 +1,5 @@
 import { render, setupOnerror, resetOnerror } from '@ember/test-helpers';
+import click from '@ember/test-helpers/dom/click';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -21,6 +22,10 @@ module('Integration | Helpers | Service', function (hooks) {
       class SomeService extends Service {
         isTrue = true;
         fruitType = 'Banana';
+
+        setFruitType(type) {
+          set(this, 'fruitType', type);
+        }
       },
     );
   });
@@ -50,5 +55,20 @@ module('Integration | Helpers | Service', function (hooks) {
     );
 
     await render(hbs`{{service "not-a-service"}}`);
+  });
+
+  test('it exposes and auto-binds methods', async function (assert) {
+    await render(hbs`
+      <button
+        type="button"
+        {{on "click" (fn (service "some-service" "setFruitType") "Apple")}}
+      >
+        {{get (service "some-service") "fruitType"}}
+      </button>
+    `);
+    assert.dom('button').hasText('Banana');
+
+    await click('button');
+    assert.dom('button').hasText('Apple');
   });
 });


### PR DESCRIPTION
Example using the [`{{pick}}` helper from `ember-composable-helpers`](https://github.com/DockYard/ember-composable-helpers#pick) to get the `event.target.checked` property.

```hbs
<label>
  Enable dark mode
  <input
    type="checkbox"
    checked={{get (service "theme") "isDark"}}
    {{on "input" (pick "target.checked" (service "theme" "toggleDarkMode"))}}
  >
</label>
```

```ts
export default class ThemeService extends Service {
  @tracked isDark = false;

  toggleDarkMode(newValue = !this.isDark) {
    // Even though this method isn't using `@action`, the `{{service}}` helper
    // binds it to the service instance.
    this.isDark = newValue;
  }
}
```