### PR TITLE
fix: remove `service` re-export

### DIFF
--- a/app/helpers/service.js
+++ b/app/helpers/service.js
@@ -1,1 +1,1 @@
-export { default, service } from 'ember-service-helper/helpers/service';
+export { default } from 'ember-service-helper/helpers/service';


### PR DESCRIPTION
Embroider emits a warning about this.